### PR TITLE
chore(package): Fixes the lerna-beta.31 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "shelljs": "0.7.0"
   },
   "peerDependencies": {
-    "lerna": "<2.0.0-beta.31"
+    "lerna": "^2.0.0-beta.31"
   },
   "devDependencies": {
     "babel-cli": "6.8.0",
     "babel-preset-es2015": "6.6.0",
     "commitizen": "1.0.5",
-    "lerna": "jpnelson/lerna#8c0e5a44",
+    "lerna": "^2.0.0-beta.31",
     "semantic-release": "^4.3.5"
   },
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,7 @@ import shell from 'shelljs';
 import path from 'path';
 
 function getAllPackages () {
-  const packagesLocation = new Repository().packagesLocation;
-  return PackageUtilities.getPackages(packagesLocation);
+  return PackageUtilities.getPackages(new Repository());
 }
 
 function getChangedPackages () {


### PR DESCRIPTION
BREAKING CHANGE: This updates the getAllPackages function to pass in a Repository rather than the
packageLocation string. This makes it incompatible with lerna < beta.31.