### PR TITLE
fix(dependencies): update outdated dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["env"]
 }

--- a/package.json
+++ b/package.json
@@ -16,26 +16,26 @@
   "author": "Joshua Nelson <jonelson@atlassian.com>, Joscha Feth <jfeth@atlassian.com>",
   "license": "MIT",
   "dependencies": {
-    "@semantic-release/commit-analyzer": "^2.0.0",
-    "chalk": "^1.1.3",
-    "cz-customizable": "^4.0.0",
-    "inquirer-autocomplete-prompt": "^0.7.0",
-    "promise": "^7.1.1",
-    "shelljs": "0.7.0"
+    "@semantic-release/commit-analyzer": "^5.0.3",
+    "chalk": "^2.3.2",
+    "cz-customizable": "^5.2.0",
+    "inquirer-autocomplete-prompt": "^0.12.2",
+    "promise": "^8.0.1",
+    "shelljs": "^0.8.1"
   },
   "peerDependencies": {
-    "lerna": "^2.0.0-beta.31"
+    "lerna": "^2.9.0"
   },
   "devDependencies": {
-    "babel-cli": "6.8.0",
-    "babel-preset-es2015": "6.6.0",
-    "babel-register": "^6.18.0",
-    "commitizen": "^2.9.5",
-    "cz-conventional-changelog": "^1.2.0",
-    "inquirer": "^3.0.4",
-    "lerna": "^2.0.0-beta.31",
-    "mocha": "^3.2.0",
-    "semantic-release": "^4.3.5"
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-register": "^6.26.0",
+    "commitizen": "^2.9.6",
+    "cz-conventional-changelog": "^2.1.0",
+    "inquirer": "^5.2.0",
+    "lerna": "^2.9.0",
+    "mocha": "^5.0.5",
+    "semantic-release": "^15.1.4"
   },
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
Closes #14 

---

## 🚧 WIP 👷 🚧 

Getting errors, but can't fix them just yet...:
```
$ mocha --compilers js:babel-register test/**/*.js


(node:78370) DeprecationWarning: "--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info
  cz-lerna-changelog


Line 1 will be cropped at 100 characters. All other lines will be wrapped after 100 characters.

(node:78370) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'log' of undefined
(node:78370) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
    1) should generate correct commit message from prompt answers


Line 1 will be cropped at 100 characters. All other lines will be wrapped after 100 characters.

(node:78370) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: Cannot read property 'log' of undefined
    2) allows questions to be overriden


  0 passing (4s)
  2 failing

  1) cz-lerna-changelog
       should generate correct commit message from prompt answers:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.


  2) cz-lerna-changelog
       allows questions to be overriden:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```