### PR TITLE
Fix affected package detection on WIndows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ function getAllPackages() {
 function getChangedPackages(allPackages) {
   const changedFiles = shell.exec('git diff --cached --name-only', { silent: true })
     .stdout
-    .split('\n');
+    .split('\n')
+    .map(path.normalize);
 
   return allPackages
     .filter(function (pkg) {


### PR DESCRIPTION
Currently affected packages are not detected on Windows due to git diff using forwardslash and npm path using backslash.

This normalizes the git diff paths before comparing them with the package paths
